### PR TITLE
fix: gif & colorscheme persistence

### DIFF
--- a/modules/launcher/WallpaperList.qml
+++ b/modules/launcher/WallpaperList.qml
@@ -11,7 +11,7 @@ PathView {
     id: root
 
     required property StyledTextField search
-    required property PersistentProperties visibilities
+    required property var visibilities
     required property var panels
     required property var content
 
@@ -27,7 +27,7 @@ PathView {
         let outerMargins = 0;
         if (panels.popouts.hasCurrent && panels.popouts.currentCenter + panels.popouts.nonAnimHeight / 2 > screen.height - content.implicitHeight - Config.border.thickness * 2)
             outerMargins = panels.popouts.nonAnimWidth;
-        if (visibilities.utilities && panels.utilities.implicitWidth > outerMargins)
+        if ((visibilities.utilities || visibilities.sidebar) && panels.utilities.implicitWidth > outerMargins)
             outerMargins = panels.utilities.implicitWidth;
         const maxWidth = screen.width - Config.border.rounding * 4 - (barMargins + outerMargins) * 2;
 

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -101,7 +101,10 @@ bool CUtils::copyFile(const QUrl& source, const QUrl& target, bool overwrite) co
     }
 
     if (overwrite) {
-        QFile::remove(target.toLocalFile());
+        if (!QFile::remove(target.toLocalFile())) {
+            qWarning() << "CUtils::copyFile: overwrite was specified but failed to remove" << target.toLocalFile();
+            return false;
+        }
     }
 
     return QFile::copy(source.toLocalFile(), target.toLocalFile());

--- a/services/Notifs.qml
+++ b/services/Notifs.qml
@@ -108,8 +108,8 @@ Singleton {
         name: "clearNotifs"
         description: "Clear all notifications"
         onPressed: {
-            for (const notif of root.list)
-                notif.popup = false;
+            for (const notif of root.list.slice())
+                notif.close();
         }
     }
 
@@ -117,8 +117,8 @@ Singleton {
         target: "notifs"
 
         function clear(): void {
-            for (const notif of root.list)
-                notif.popup = false;
+            for (const notif of root.list.slice())
+                notif.close();
         }
 
         function isDndEnabled(): bool {


### PR DESCRIPTION
The `~/.local/state/caelestia/wallpaper/path.txt` wasn't actually updating on gif selection, while the CLI get function was, so restarting the shell didn't apply the previously set gif, but instead the last valid static image.


`is_valid_image()` in the wallpaper.py, from the caelestia-cli-git would need to be updated to also include gifs for it to not error and actually write the path.
```python
def is_valid_image(path: Path) -> bool:
    return path.is_file() and path.suffix.lower() in [
        ".jpg", ".jpeg", ".png", ".webp", ".tif", ".tiff", ".gif", ".svg"
    ]
```


This PR is really just a quick bypass of the CLI, instead just writing to the .txt for the path, and JSON for the colors.
Actually updating the CLI would be better, but I'm not sure how much that actually gets updated/merged PRs, but this workaround feels a bit like one of those "yeah, just use the CLI" haha


_(of course I pulled in the upstream updates just because I merged yours in to a clean branch lol)_